### PR TITLE
wip remove create user refs, update get requests

### DIFF
--- a/python/daco_client.py
+++ b/python/daco_client.py
@@ -103,20 +103,9 @@ class DacoClient(object):
         if self.ego_client.user_exists(user.email):
             return self.existing_user(user)
 
-        return self.new_user(user)
+        self.count('ego_user_not_found')
+        return f"User is not in ego, no access granted to '{user}'"
 
-    # scenario 1
-    def new_user(self, user):
-        self.create_user(user)
-        self.grant_daco(user)
-
-        if not user.has_cloud:
-            self.count('new_daco')
-            return f"Created user '{user}' with daco access"
-
-        self.grant_cloud(user)
-        self.count('new_cloud')
-        return f"Created user '{user}' with cloud access"
 
     # scenario 2
     def existing_user(self, user):
@@ -190,16 +179,17 @@ class DacoClient(object):
             return self.ego_client.user_exists(user.email)
         except Exception as e:
             self.count('user exists check', err=True)
+            self.count(f"Ego user not found for user `{user}'", err=True)
             raise LookupError(f"Can't tell if user '{user} is already in "
                               f"ego", e)
 
-    def create_user(self, user, msg=None):
+    def ego_user_not_found(self, user, msg=None):
         if msg is None:
-            msg = f"Can't create user '{user}'"
+            msg = f"User does not exist in ego, no access changes for '{user}'"
         try:
-            self.ego_client.create_user(user.email, user.name)
+            self.ego_client
         except Exception as e:
-            self.count('create user', err=True)
+            self.count(f"Ego user not found for user `{user}'", err=True)
             raise LookupError(msg, e)
 
     def has_daco(self, user, msg=None):

--- a/python/ego_client.py
+++ b/python/ego_client.py
@@ -63,7 +63,6 @@ class EgoClient(object):
         return self._rest_client.delete(self.base_url + endpoint)
 
     def _field_search(self, query, name, value):
-        # query = endpoint + f"?{name}={value}&limit=9999999"
         result = self._get_json(query)
         if result['count'] == 0:
             raise IOError(f"No matches for {value} from ego endpoint {query}",

--- a/python/report.py
+++ b/python/report.py
@@ -6,7 +6,7 @@ def zero_defaults(fields, dictionary):
 
 def summarize(c):
     fields = ("new_daco", "new_cloud", "grant_daco", "grant_cloud", "grant_both",
-              "revoke_daco", "revoke_cloud", "revoke_invalid")
+              "revoke_daco", "revoke_cloud", "revoke_invalid", "ego_user_not_found")
     counts = zero_defaults(fields, c)
 
     counts['new'] = counts['new_daco'] + counts['new_cloud']
@@ -21,8 +21,10 @@ def summarize(c):
                ('revoke_cloud', "Revoked Cloud access from {revoke_cloud} existing users."),
                ('revoke',
                 "Revoked DACO and Cloud access from {revoke} existing users "
-                "({revoke_invalid} of them were invalid users).")
+                "({revoke_invalid} of them were invalid users)."),
+               ('ego_user_not_found', "{ego_user_not_found} users were not registered in Ego.")
                )
+
     report_fields = [u[0] for u in updates]
     if not any([counts[f] for f in report_fields]):
         return "*Updates*: No updates\n"
@@ -39,10 +41,10 @@ def summarize(c):
 
 
 def report_warnings(c):
-    fields = ("multiple_entries", "invalid", "invalid_email", "revoke_invalid")
+    fields = ("multiple_entries", "invalid", "invalid_email", "revoke_invalid", "ego_user_not_found")
     counts = zero_defaults(fields, c)
 
-    if not (counts['multiple_entries'] or counts['invalid'] or counts['invalid_email']):
+    if not (counts['multiple_entries'] or counts['invalid'] or counts['invalid_email'] or counts['ego_user_notfound']):
         return ""
 
     report = "\n*Warnings*:\n"
@@ -50,7 +52,8 @@ def report_warnings(c):
     warnings = (('multiple_entries', "{} multiple entries found in configuration file"),
                 ('invalid_email', "{} invalid OpenId email addresses found in configuration file"),
                 ('invalid', '{}' + f" invalid users found with Cloud access but not DACO access "
-                f"({counts['revoke_invalid']} had access to revoke)"))
+                f"({counts['revoke_invalid']} had access to revoke)"),
+                ('ego_user_not_found', "{} users from configuration file not found in Ego."))
 
     for category, message in warnings:
         try:

--- a/python/tests/mock_ego_client.py
+++ b/python/tests/mock_ego_client.py
@@ -37,11 +37,8 @@ class MockEgoSuccess(MockIO):
         for g in self.groups.values():
             if user in g:
                 return True
+        self.log_call('ego_user_not_found', user)
         return False
-
-    def create_user(self, user, name):
-        self.log_call('create_user', (user, name))
-        self.groups['users'] = user
 
     def add(self, group, users):
         assert len(users) == 1

--- a/python/tests/test_daco_client.py
+++ b/python/tests/test_daco_client.py
@@ -369,7 +369,6 @@ def test_update_ego():
                        ('daco', 'h@ca'), ('daco', 'i@ca'), ('cloud', 'h@ca'), ('daco', 'j@ca'),
                        ('cloud', 'a@ca'), ('cloud', 'f@ca'), ('daco', 'k@ca'), ('cloud', 'k@ca')]),
         ('add', [('daco', 'a@ca'), ('daco', 'aa@ca'), ('cloud', 'aa@ca'), ('cloud', 'b@ca')]),
-        # ('ego_user_not_found', [('d@ca', 'Person D'), ('e@ca', 'Person E')]),
         ('ego_user_not_found', [('d@ca'), ('e@ca')]),
         ('get_users', ['daco', 'cloud']),
         ('remove', [('daco', 'i@ca'), ('cloud', 'i@ca'), ('daco', 'j@ca'), ('cloud', 'j@ca'), ('daco', 'c@ca'),

--- a/python/tests/test_ego_client.py
+++ b/python/tests/test_ego_client.py
@@ -37,14 +37,9 @@ def test_ego_client():
     client = init()
     user, name = "test@gmail.com", "Test User"
 
+    # users cannot be created manually in Ego 4, so this test needs to be run with an existing user
     if not client.user_exists(user):
-        has_daco(client, user, False)
-        has_cloud(client, user, False)
-
-        u = client.create_user(user, name)
-        print(u)
-
-        assert client.user_exists(user)
+        assert client.ego_user_not_found(user)
 
     exists(client, user, True)
     has_daco(client, user, False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Crypto
 atomicwrites==1.2.1
 attrs==18.2.0
 certifi==2018.11.29


### PR DESCRIPTION
- do not create user when user is not found in Ego (for Ego 4, no manual creation)
- log a user not found event when daco list user not found in Ego
- add providerType param to users GET request
- added fix to Ego so param filters get passed from query https://github.com/overture-stack/ego/pull/604